### PR TITLE
Adds second interface as optional to cyclone profile

### DIFF
--- a/docker/raspberry/launch_content/cyclone_profile.xml
+++ b/docker/raspberry/launch_content/cyclone_profile.xml
@@ -7,7 +7,8 @@
     <Domain Id="any">
         <General>
             <Interfaces>
-                <NetworkInterface name="eth0" priority="10" multicast="true" />
+                <NetworkInterface name="eth0" priority="10" multicast="true" presence_required="true"/>
+                <NetworkInterface name="wlan0" priority="11" multicast="true" presence_required="false"/>
             </Interfaces>
             <AllowMulticast>true</AllowMulticast>
             <MaxMessageSize>65500B</MaxMessageSize>


### PR DESCRIPTION
- ethernet = required
- wifi = optional